### PR TITLE
Config.unobserve is deprecated.

### DIFF
--- a/lib/linter-bootlint.coffee
+++ b/lib/linter-bootlint.coffee
@@ -30,6 +30,6 @@ class LinterBootlint extends Linter
       @executablePath = atom.config.get 'linter-bootlint.bootlintExecutablePath'
 
   destroy: ->
-    atom.config.unobserve 'linter-bootlint.bootlintExecutablePath'
+    atom.config.dispose
 
 module.exports = LinterBootlint


### PR DESCRIPTION
Just a quick fix for the latest version of atom v0.189

Config::unobserve no longer does anything. Call `.dispose()` on the object returned by Config::observe instead.
```
Config.unobserve (C:\Users\Ben\AppData\Local\atom\app-0.189.0\resources\app\src\config.js:374:19)
LinterBootlint.destroy (C:\Users\Ben\.atom\packages\linter-bootlint\lib\linter-bootlint.coffee:33:16)
```