### PR TITLE
Fixed the deprecated call introduced in atom v0.196 + Add bootlint flag support

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -6,6 +6,10 @@ module.exports =
       type: 'string'
       default: path.join __dirname, '..', 'node_modules', '.bin'
       description: 'Path of the `bootlinter` executable'
+    flags:
+      type: 'string'
+      default: ''
+      description: 'Disable certain lint checks (comma-separated), refer to bootlint github page for error codes'
 
   activate: ->
     console.log 'activate linter-bootlint'

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -1,8 +1,11 @@
 path = require 'path'
 
 module.exports =
-  configDefaults:
-    bootlintExecutablePath: path.join __dirname, '..', 'node_modules', '.bin'
+  config:
+    executablePath:
+      type: 'string'
+      default: path.join __dirname, '..', 'node_modules', '.bin'
+      description: 'Path of the `bootlinter` executable'
 
   activate: ->
     console.log 'activate linter-bootlint'

--- a/lib/linter-bootlint.coffee
+++ b/lib/linter-bootlint.coffee
@@ -1,6 +1,5 @@
 linterPath = atom.packages.getLoadedPackage('linter').path
 Linter = require "#{linterPath}/lib/linter"
-findFile = require "#{linterPath}/lib/util"
 
 class LinterBootlint extends Linter
   # The syntax that the linter handles. May be a string or
@@ -26,10 +25,10 @@ class LinterBootlint extends Linter
   constructor: (editor) ->
     super(editor)
 
-    atom.config.observe 'linter-bootlint.bootlintExecutablePath', =>
-      @executablePath = atom.config.get 'linter-bootlint.bootlintExecutablePath'
+    @listener = atom.config.observe 'linter-bootlint.executablePath', =>
+      @executablePath = atom.config.get 'linter-bootlint.executablePath'
 
   destroy: ->
-    atom.config.dispose
+    @listener.dispose()
 
 module.exports = LinterBootlint

--- a/lib/linter-bootlint.coffee
+++ b/lib/linter-bootlint.coffee
@@ -8,8 +8,7 @@ class LinterBootlint extends Linter
 
   # A string, list, tuple or callable that returns a string, list or tuple,
   # containing the command line (with arguments) used to lint.
-
-  cmd: "bootlint -d #{atom.config.get 'linter-bootlint.flags'}"
+  cmd: 'bootlint'
 
   linterName: 'bootlint'
 
@@ -25,6 +24,9 @@ class LinterBootlint extends Linter
 
   constructor: (editor) ->
     super(editor)
+
+    flags = atom.config.get 'linter-bootlint.flags'
+    @cmd += " -d #{flags}" if flags
 
     @listener = atom.config.observe 'linter-bootlint.executablePath', =>
       @executablePath = atom.config.get 'linter-bootlint.executablePath'

--- a/lib/linter-bootlint.coffee
+++ b/lib/linter-bootlint.coffee
@@ -8,7 +8,8 @@ class LinterBootlint extends Linter
 
   # A string, list, tuple or callable that returns a string, list or tuple,
   # containing the command line (with arguments) used to lint.
-  cmd: 'bootlint'
+
+  cmd: "bootlint -d #{atom.config.get 'linter-bootlint.flags'}"
 
   linterName: 'bootlint'
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "linter-bootlint",
   "main": "./lib/init",
   "linter-package": true,
-  "activationEvents": [],
+  "activationCommands": {},
   "version": "0.0.5",
   "description": "Lint Bootstrap HTML on the fly, using bootlint",
   "repository": "https://github.com/AtomLinter/linter-bootlint",


### PR DESCRIPTION
Changed init.coffee over to the new config schema (Old style has be deprecated)
Changed activationEvents to activationCommands (activationEvents has been deprecated)
Removed findFile include wasn't being used
Fixed disposable of right object when linter is destroyed