### PR TITLE
Guard against TextEditors with no path

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -53,6 +53,11 @@ export default {
       lintOnFly: true,
       lint: (textEditor) => {
         const filePath = textEditor.getPath();
+        if (!filePath) {
+          // Linter gave us a TextEditor with no path
+          return null;
+        }
+
         const fileDir = path.dirname(filePath);
         const text = textEditor.getText();
 


### PR DESCRIPTION
Add a check preventing any work on a TextEditor that has no path associated with it.

Fixes #102.